### PR TITLE
Document PharmChain architecture and fix batch registry interface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Copy this file to .env and fill in the values before running the services.
+
+# Gemini API (used by PharmToTable and consumer demos)
+GEMINI_API_KEY=your-google-gemini-key
+
+# Blockchain connectivity
+BLOCKCHAIN_PROVIDER_URL=http://localhost:8545
+CONTRACT_ADDRESS=0xYourContractAddress
+PRIVATE_KEY=0xyourprivatekey # never commit the real value!
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,128 @@
-# pharmchain
+# PharmChain
+
+PharmChain is a full-stack exploration of how blockchain, zero-knowledge proofs, and AI-assisted analysis can reinforce trust in pharmaceutical supply chains. The repository combines Solidity smart contracts, a FastAPI service that augments blockchain records with Gemini-powered insights, multiple user-facing clients, and demo utilities for rapid experimentation.
+
+> **Why this repo?** Use PharmChain to prototype end-to-end drug provenance workflows, from registering batches on-chain to issuing prescriptions, proving credentials, and surfacing traceability data through web and data-science friendly interfaces.
+
+## Highlights
+
+- **Modular smart-contract suite** for manufacturers, wholesalers, pharmacies, and doctors with strict role-based access control.
+- **Transfer and prescription tracking** plus optional zero-knowledge credential hashing for privacy-preserving compliance checks.
+- **AI-enhanced verification workflows** that inspect uploaded documents, ledgers, and blockchain activity using Gemini models.
+- **Multiple user experiences** including a React dApp, a Streamlit analyst console, and a lightweight consumer-facing Flask demo with QR codes.
+- **Ready-to-run scripts** for compiling Circom circuits, deploying contracts with Hardhat, and experimenting with zk-SNARK proofs.
+
+## Repository layout
+
+| Path | Description |
+| --- | --- |
+| `contracts/` | Solidity contracts for roles, batch registration, transfers, prescriptions, and credential hashes plus shared interfaces. |
+| `scripts/deploy.js` | Hardhat deployment script that bootstraps the entire contract suite. |
+| `PharmToTable/` | FastAPI backend, Gemini helper utilities, and Streamlit dashboard for operational teams. |
+| `front-end/` | React + TypeScript dApp that connects to the deployed contracts, handles IPFS uploads, and manages user dashboards. |
+| `consumer/` | Flask demo that fabricates traceability data, generates QR codes, and (optionally) summarizes data with Gemini. |
+| `docs/` | Extended documentation including architecture notes, smart contract references, and development tips. |
+| `scripts/` | Circom/snarkjs utilities for zero-knowledge experimentation. |
+
+## Quick start
+
+> **Prerequisites:** Node.js ≥ 18, npm, Python ≥ 3.10, and (optionally) a local Ethereum node such as Hardhat or Ganache. Install [pnpm](https://pnpm.io) if you prefer a faster Node package manager.
+
+### 1. Clone and install dependencies
+
+```bash
+npm install          # Installs Hardhat, snarkjs, and solidity tooling
+cd PharmToTable && pip install -r requirements.txt
+cd ../consumer && pip install -r requirements.txt
+cd ../front-end && npm install
+```
+
+### 2. Configure environment variables
+
+Copy `.env.example` files and populate them with real values before running any service:
+
+```bash
+cp .env.example .env                            # Back-end and scripts
+cp front-end/.env.example front-end/.env        # React dApp
+```
+
+At minimum you will need:
+
+- `GEMINI_API_KEY` for Gemini-based features (FastAPI and consumer demo).
+- `BLOCKCHAIN_PROVIDER_URL`, `CONTRACT_ADDRESS`, and `PRIVATE_KEY` for on-chain writes.
+- `REACT_APP_PINATA_JWT` and `REACT_APP_GATEWAY_URL` for IPFS uploads from the dApp.
+
+See the [environment reference](docs/development.md#environment-variables) for the full list.
+
+### 3. Compile and deploy the contracts
+
+```bash
+npx hardhat compile
+npx hardhat run scripts/deploy.js --network ganache   # or your preferred network
+```
+
+Record the deployed addresses and update `front-end/src/constants/contracts.ts` plus any server configuration that depends on them.
+
+### 4. Run the FastAPI service
+
+```bash
+cd PharmToTable
+uvicorn app:app --reload
+```
+
+The API exposes endpoints for document processing, ledger analysis, medication verification, journey visualization, and batch uploads. Refer to [`docs/development.md`](docs/development.md#fastapi-service) for endpoint summaries and payload examples.
+
+### 5. Launch the Streamlit analyst console (optional)
+
+```bash
+cd PharmToTable
+streamlit run frontend.py
+```
+
+This UI lets analysts verify medications, inspect blockchain history, and orchestrate batch jobs powered by the FastAPI endpoints.
+
+### 6. Explore the React dApp
+
+```bash
+cd front-end
+npm start
+```
+
+Connect with MetaMask or another wallet pointing at your test network. Role management, batch registration, transfers, prescriptions, and credential issuance are surfaced through dedicated dashboards.
+
+### 7. Try the consumer QR-code demo (optional)
+
+```bash
+cd consumer
+export FLASK_APP=main.py
+flask run --port 8080
+```
+
+Visit `http://localhost:8080` to see fabricated traceability data. Summaries will include AI-generated content if `GEMINI_API_KEY` is set; otherwise a helpful message is displayed.
+
+## Documentation
+
+- [Architecture overview](docs/architecture.md)
+- [Smart contract reference](docs/smart_contracts.md)
+- [Development playbook](docs/development.md)
+
+Each document includes cross-links, diagrams-in-words, and callouts for environment management and security considerations.
+
+## Security & secrets
+
+- **Never commit API keys or private keys.** Use the provided `.env.example` files and environment variables.
+- The consumer demo intentionally fabricates data; do not rely on it for production signals.
+- Audit and update Hardhat network credentials (`hardhat.config.js`) before deploying to real networks.
+
+## Contributing
+
+1. Fork the repository and create a topic branch.
+2. Keep linting, type checking, and Hardhat compilation clean.
+3. Open a pull request with context about the problem being solved. Screenshots or call traces are welcome.
+
+See [`docs/development.md`](docs/development.md#quality-checks) for useful commands.
+
+## License
+
+This project is published under the ISC license (see `package.json`). Individual files may carry additional SPDX identifiers where appropriate.
+

--- a/consumer/ai.py
+++ b/consumer/ai.py
@@ -1,11 +1,21 @@
+import os
+from typing import Optional
+
 import requests
 from flask import Flask, render_template_string, request
 
 app = Flask(__name__)
 
-# Your Gemini API key
-API_KEY = 'AIzaSyBhUKYFqXoZT2VuFkFlm9ChtN6KKDhD-9w'
-GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=' + API_KEY
+# Gemini API configuration (optional for the demo)
+API_KEY: Optional[str] = os.getenv("GEMINI_API_KEY")
+GEMINI_API_URL: Optional[str] = None
+
+if API_KEY:
+    GEMINI_API_URL = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "gemini-2.0-flash:generateContent?key="
+        + API_KEY
+    )
 
 # Example detailed drug information
 drug_info = {
@@ -20,6 +30,9 @@ drug_info = {
 
 # Function to summarize drug information using Gemini API
 def summarize_with_gemini(text):
+    if not GEMINI_API_URL:
+        return "Gemini summarization is disabled. Set the GEMINI_API_KEY environment variable to enable this feature."
+
     headers = {
         'Content-Type': 'application/json',
     }

--- a/consumer/main.py
+++ b/consumer/main.py
@@ -2,16 +2,25 @@ import qrcode
 import json
 import hashlib
 import random
+import os
+from typing import Optional
+
 from faker import Faker
 from flask import Flask, render_template_string, request
-import os
 import requests
 
 app = Flask(__name__)
 
-# Your Gemini API key
-API_KEY = 'AIzaSyBhUKYFqXoZT2VuFkFlm9ChtN6KKDhD-9w'
-GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=' + API_KEY
+# Gemini API configuration (optional for the demo)
+API_KEY: Optional[str] = os.getenv("GEMINI_API_KEY")
+GEMINI_API_URL: Optional[str] = None
+
+if API_KEY:
+    GEMINI_API_URL = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "gemini-2.0-flash:generateContent?key="
+        + API_KEY
+    )
 
 # Initialize Faker for generating fake data
 fake = Faker()
@@ -102,6 +111,9 @@ def generate_qr_code(drug_id):
 
 # Function to summarize drug information using Gemini API
 def summarize_with_gemini(text):
+    if not GEMINI_API_URL:
+        return "Gemini summarization is disabled. Set the GEMINI_API_KEY environment variable to enable this feature."
+
     headers = {
         'Content-Type': 'application/json',
     }

--- a/contracts/PrescriptionRegistry.sol
+++ b/contracts/PrescriptionRegistry.sol
@@ -63,7 +63,7 @@ contract PrescriptionRegistry {
         require(bytes(ipfsCID).length > 0, "Invalid IPFS CID");
 
         // Validate batch
-        (,,uint256 registeredAt) = batchRegistry.getBatch(batchId);
+        (,,,,,, uint256 registeredAt) = batchRegistry.getBatch(batchId);
         require(registeredAt > 0, "Batch not registered");
 
         prescriptions[prescriptionId] = Prescription({

--- a/contracts/TransferTracker.sol
+++ b/contracts/TransferTracker.sol
@@ -57,7 +57,7 @@ contract TransferTracker {
         bytes32 batchIdHash = keccak256(bytes(batchId));
 
         // Ensure batch exists
-        (,,uint256 registeredAt) = batchRegistry.getBatch(batchId);
+        (,,,,,, uint256 registeredAt) = batchRegistry.getBatch(batchId);
         require(registeredAt > 0, "Batch not registered");
 
         Transfer memory t = Transfer({

--- a/contracts/interfaces/IDrugBatchRegistry.sol
+++ b/contracts/interfaces/IDrugBatchRegistry.sol
@@ -2,9 +2,16 @@
 pragma solidity ^0.8.20;
 
 interface IDrugBatchRegistry {
-    function getBatch(string memory batchId) external view returns (
-        string memory ipfsCID,
-        address manufacturer,
-        uint256 registeredAt
-    );
+    function getBatch(string memory batchId)
+        external
+        view
+        returns (
+            string memory name,
+            string memory dosage,
+            string memory expirationDate,
+            string memory description,
+            string memory ipfsCID,
+            address manufacturer,
+            uint256 registeredAt
+        );
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,72 @@
+# Architecture overview
+
+PharmChain spans on-chain logic, AI-assisted services, and multiple user experiences. The diagram below captures the major moving parts and the relationships between them.
+
+```
+┌──────────────────────┐        ┌──────────────────────────┐
+│  React dApp (front-end) ─────▶│  Solidity contracts      │
+│  Streamlit console     │◀─────│  (Hardhat deployments)   │
+└──────────▲────────────┘        └──────────┬──────────────┘
+           │                                 │
+           │ REST/JSON                       │ events/calls
+           │                                 ▼
+┌──────────┴────────────┐        ┌──────────────────────────┐
+│ FastAPI service        │◀──────│ Ethereum-compatible node │
+│ (PharmToTable/app.py)  │──────▶│ (Hardhat, Ganache, etc.) │
+└──────────▲────────────┘        └──────────────────────────┘
+           │
+           │ gRPC/HTTP to Gemini, IPFS SDK, analytics
+           ▼
+┌────────────────────────┐
+│ Gemini APIs & external │
+│ services (Pinata, etc.)│
+└────────────────────────┘
+```
+
+## Core domains
+
+### On-chain governance and traceability
+
+- **RoleAccessControl** enforces who may register drug batches, handle transfers, issue prescriptions, or mint zero-knowledge credential hashes.
+- **DrugBatchRegistry** captures rich metadata (name, dosage, description, IPFS CID, etc.) for each batch registered by a manufacturer.
+- **TransferTracker** records transfers from manufacturers → wholesalers → pharmacies and emits events for downstream analytics.
+- **PrescriptionRegistry** links a doctor-approved prescription ID to a batch and tracks when pharmacies fulfil it.
+- **ZKCredentialIssuer** stores hashes of off-chain credentials that can be proven with zk-SNARKs without revealing sensitive data.
+
+All contracts are deployed via `scripts/deploy.js`, which wires addresses together and prints a summary for client configuration.
+
+### Off-chain services (PharmToTable)
+
+`PharmToTable/app.py` exposes a FastAPI service that acts as the connective tissue between blockchain records and AI assistance:
+
+- `/api/process-document` uploads package or transfer imagery and uses Gemini to extract structured fields.
+- `/api/analyze-ledger` ingests CSV/Excel ledgers and asks Gemini to summarise anomalies and risk factors.
+- `/api/verify-medication` cross-checks scanned data against blockchain history and returns a blended authenticity score.
+- `/api/journey-map/{lot}` produces journey visualisation scaffolding for the Streamlit UI.
+- `/api/batch-process` triggers large CSV verifications asynchronously.
+
+`gemini_helpers.py` contains the prompt engineering and parsing logic for each AI-powered workflow, while `blockchain.py` wraps Web3 calls against the deployed contracts.
+
+### User experiences
+
+- **React dApp (`front-end/`)**: wallet-connected dashboards for admins, manufacturers, pharmacies, and doctors. Uses the services in `src/services` to interact directly with contracts and IPFS.
+- **Streamlit analyst console (`PharmToTable/frontend.py`)**: a rapid-prototyping interface over the FastAPI endpoints that analysts can use without handling wallets.
+- **Consumer demo (`consumer/`)**: a Flask app that fabricates QR-coded traceability records and can optionally call Gemini for educational summaries.
+
+## Data flow highlights
+
+1. **Batch registration**: A manufacturer registers a batch in `DrugBatchRegistry`. The transaction emits `BatchRegistered`, which can be consumed by analytics dashboards. IPFS CIDs reference packaging or COAs stored off-chain.
+2. **Transfer logging**: Wholesalers and pharmacies call `TransferTracker.logTransfer`. The contract validates role pairings (manufacturer → wholesaler → pharmacy) and persists the transfer history for auditors.
+3. **Prescription lifecycle**: Doctors issue prescriptions tied to batches. Pharmacies mark fulfilment, enabling end-to-end visibility between medical orders and inventory.
+4. **AI verification**: Off-chain scans or ledgers are uploaded to FastAPI. Gemini produces structured data or insights, which are merged with blockchain history before returning to the caller.
+5. **Zero-knowledge credentials**: Authorised entities hash credentials off-chain, submit the hash via `ZKCredentialIssuer`, and later prove possession without revealing raw data.
+
+## Operational considerations
+
+- **Secrets management**: `PharmToTable/config.py` requires `GEMINI_API_KEY` and blockchain credentials; never hard-code secrets in source files.
+- **Extensibility**: The interfaces in `contracts/interfaces/` are intentionally lean to allow contracts to evolve while keeping type safety for cross-contract calls.
+- **Event-driven integrations**: Consider consuming Hardhat node logs or using services like The Graph to build reactive dashboards.
+- **Testing**: Use Hardhat's `npx hardhat test` to add coverage for role gating and business rules. Python services can be covered with `pytest`.
+
+Consult [`docs/smart_contracts.md`](smart_contracts.md) for function-level breakdowns and [`docs/development.md`](development.md) for environment setup.
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,114 @@
+# Development playbook
+
+This guide consolidates setup steps, environment variables, and useful commands for working on PharmChain.
+
+## Environment variables
+
+Create a `.env` file at the repository root (see `.env.example`) with the following keys:
+
+| Variable | Purpose |
+| --- | --- |
+| `GEMINI_API_KEY` | Required for Gemini API calls (`PharmToTable` services and `consumer` demo). |
+| `BLOCKCHAIN_PROVIDER_URL` | HTTP endpoint for your Ethereum node (Hardhat, Ganache, Infura, etc.). |
+| `CONTRACT_ADDRESS` | Address of the deployed contract that `PharmToTable/blockchain.py` interacts with. |
+| `PRIVATE_KEY` | Private key for signing blockchain transactions when registering medications or logging transfers. |
+
+Additional component-specific variables:
+
+- **React dApp (`front-end`)**: copy `front-end/.env.example` and configure `REACT_APP_PINATA_JWT`, `REACT_APP_GATEWAY_URL`, and any RPC URLs required by your wallet provider.
+- **Hardhat**: customise `hardhat.config.js` to point at your preferred networks and funded accounts.
+
+## Installing dependencies
+
+```bash
+# Solidity toolchain
+npm install
+
+# FastAPI service & Streamlit console
+cd PharmToTable
+pip install -r requirements.txt
+
+# Consumer Flask demo
+cd ../consumer
+pip install -r requirements.txt
+
+# React dApp
+cd ../front-end
+npm install
+```
+
+Python projects assume a virtual environment; use `python -m venv .venv && source .venv/bin/activate` before installing.
+
+## Running the services
+
+### Hardhat node (optional)
+
+```bash
+npx hardhat node
+```
+
+Use `npx hardhat run scripts/deploy.js --network localhost` to deploy into the in-memory chain.
+
+### FastAPI
+
+```bash
+cd PharmToTable
+uvicorn app:app --reload
+```
+
+Endpoints are documented inline in `app.py`. Use `http://localhost:8000/docs` for Swagger UI once the server is running.
+
+### Streamlit console
+
+```bash
+cd PharmToTable
+streamlit run frontend.py
+```
+
+### Consumer demo
+
+```bash
+cd consumer
+export FLASK_APP=main.py
+flask run --port 8080
+```
+
+Summaries will only include AI output when `GEMINI_API_KEY` is present.
+
+### React dApp
+
+```bash
+cd front-end
+npm start
+```
+
+The development server runs on `http://localhost:3000` and expects browser wallets to be connected to the same network as your deployed contracts.
+
+## Quality checks
+
+Recommended commands before opening a pull request:
+
+```bash
+# Solidity
+npx hardhat compile
+npx hardhat test
+
+# Python (from repository root)
+ruff check PharmToTable consumer
+pytest PharmToTable/tests  # if/when tests are added
+
+# React
+cd front-end
+npm run lint
+npm test
+```
+
+Adjust tooling as linters/tests are introduced. Keep `npm audit` and dependency updates in mind for long-lived deployments.
+
+## Troubleshooting tips
+
+- **Missing Gemini key**: Both FastAPI and the consumer demo gracefully return explanatory messages if `GEMINI_API_KEY` is absent. Set the variable to restore summarisation features.
+- **Contract ABI mismatch**: Regenerate ABIs after modifying Solidity (`npx hardhat compile`) and make sure `PharmToTable/contracts/*.json` and `front-end/src/abi` are refreshed.
+- **Ganache vs. Hardhat**: Update `hardhat.config.js` if you prefer a different local chain, and double-check `CONTRACT_ADDRESS` across services.
+- **Pinata setup**: Obtain a Pinata JWT and gateway URL, then populate `front-end/.env`. Without these values, IPFS uploads from the React dApp will fail fast with a descriptive error.
+

--- a/docs/smart_contracts.md
+++ b/docs/smart_contracts.md
@@ -1,0 +1,88 @@
+# Smart contract reference
+
+This document summarises the Solidity contracts in `contracts/` and how they collaborate to enforce pharmaceutical supply-chain rules.
+
+## RoleAccessControl.sol
+
+`RoleAccessControl` inherits from OpenZeppelin's `AccessControl` and seeds the deployer as the default admin. It defines the following role identifiers:
+
+- `MANUFACTURER_ROLE`
+- `WHOLESALER_ROLE`
+- `PHARMACY_ROLE`
+- `DOCTOR_ROLE`
+- `ADMIN_ROLE` (alias of `DEFAULT_ADMIN_ROLE`)
+
+### Admin functions
+
+| Function | Description |
+| --- | --- |
+| `registerManufacturer(address account)` | Grants the manufacturer role. |
+| `registerWholesaler(address account)` | Grants the wholesaler role. |
+| `registerPharmacy(address account)` | Grants the pharmacy role. |
+| `registerDoctor(address account)` | Grants the doctor role. |
+
+Each helper wraps `grantRole` and can only be called by an account with `ADMIN_ROLE`. Introspection helpers (`isManufacturer`, `isWholesaler`, `isPharmacy`, `isDoctor`) expose role membership to other contracts.
+
+## DrugBatchRegistry.sol
+
+Stores immutable batch metadata keyed by the keccak hash of a human-readable batch ID.
+
+- `registerBatch(...)` requires the sender to hold `MANUFACTURER_ROLE`, prevents duplicate batch IDs, and emits `BatchRegistered` with the raw string ID.
+- `getBatch(batchId)` returns the full metadata tuple `(name, dosage, expirationDate, description, ipfsCID, manufacturer, registeredAt)` and reverts if the batch has not been registered.
+- `getAllBatchIds()` exposes a list of stored hashes for off-chain indexing.
+
+Use `ipfsCID` to reference packaging images or lab certificates stored off-chain.
+
+## TransferTracker.sol
+
+Tracks authorised transfers along the supply chain.
+
+- Constructor parameters are the addresses of `RoleAccessControl` and `DrugBatchRegistry`.
+- `logTransfer(batchId, to, ipfsCID)` verifies:
+  - `msg.sender` and `to` form a valid role pairing (manufacturer → wholesaler or wholesaler → pharmacy).
+  - The batch exists in `DrugBatchRegistry`.
+  - An `ipfsCID` is supplied for encrypted shipping metadata.
+- Transfers are appended to `batchTransfers[batchHash]` and emitted via `TransferLogged` along with an aggregated count event.
+- `getTransferHistory(batchId)` and `getTransferCount(batchId)` return stored history for auditors.
+
+## PrescriptionRegistry.sol
+
+Ties doctor-issued prescriptions to registered drug batches.
+
+- `issuePrescription(prescriptionId, batchId, patient, ipfsCID)` can only be invoked by a doctor. It ensures uniqueness per `prescriptionId`, validates the batch exists, and emits `PrescriptionIssued`.
+- `fulfillPrescription(prescriptionId)` is restricted to pharmacies. It flips the fulfilment flags and emits `PrescriptionFulfilled`.
+- `getPrescription(prescriptionId)` returns the stored struct for UI consumption.
+
+## ZKCredentialIssuer.sol
+
+Records hashed credentials that can later be proven off-chain via zk-SNARKs.
+
+- `issueCredentialHash(credentialHash, schema, subject)` is available to doctors, manufacturers, and pharmacies. It stores metadata including the issuer and timestamp, then emits `CredentialIssued`.
+- `verifyCredentialHash(credentialHash)` lets consumers confirm whether a hash has been registered.
+
+## Interfaces
+
+- `IRoleAccessControl` exposes `isDoctor`, `isManufacturer`, `isPharmacy`, and `isWholesaler` so that dependent contracts can check permissions without knowing the implementation details.
+- `IDrugBatchRegistry` mirrors the full `getBatch` signature to ensure destructuring yields the same tuple order in cross-contract calls.
+- `IVerifier` (used by zk circuits) is provided for future zero-knowledge integrations.
+
+## Events and indexing tips
+
+| Contract | Event | Purpose |
+| --- | --- | --- |
+| `DrugBatchRegistry` | `BatchRegistered` | Index new batches, build product catalogues. |
+| `TransferTracker` | `TransferLogged`, `TransferCountUpdated` | Feed logistics dashboards and anomaly detection. |
+| `PrescriptionRegistry` | `PrescriptionIssued`, `PrescriptionFulfilled` | Link medical orders to fulfilment and detect fraud. |
+| `ZKCredentialIssuer` | `CredentialIssued` | Track credential provenance without leaking PII. |
+
+Consume these events with The Graph, Hardhat listeners, or server-side workers to keep off-chain databases in sync.
+
+## Deployment workflow
+
+1. Deploy `RoleAccessControl` with an admin address.
+2. Deploy `DrugBatchRegistry`, `ZKCredentialIssuer`, `TransferTracker`, and `PrescriptionRegistry`, passing the access-control address (and batch registry where required).
+3. Register initial accounts with the appropriate roles via `RoleAccessControl`.
+4. Update client configuration (`front-end/src/constants/contracts.ts`, environment variables) with the deployed addresses.
+
+See [`scripts/deploy.js`](../scripts/deploy.js) for an automated deployment sequence.
+

--- a/front-end/.env.example
+++ b/front-end/.env.example
@@ -1,0 +1,7 @@
+# Environment variables consumed by the React dApp (create-react-app convention)
+
+REACT_APP_PINATA_JWT=eyJhbGciOi... # Pinata JWT with IPFS write access
+REACT_APP_GATEWAY_URL=https://your-gateway.pinata.cloud
+REACT_APP_DEFAULT_NETWORK=0x539            # Hardhat chain id (0x539 = 1337)
+REACT_APP_RPC_URL=http://localhost:8545    # Optional custom RPC endpoint for wallet connectors
+

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -1,46 +1,55 @@
-# Getting Started with Create React App
+# PharmChain React dApp
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This package delivers a wallet-connected dashboard for managing pharmaceutical supply-chain workflows on top of the PharmChain smart contracts.
 
-## Available Scripts
+## Features
 
-In the project directory, you can run:
+- Role-aware navigation for admins, manufacturers, wholesalers, pharmacies, and doctors.
+- Batch registration and IPFS-backed document storage using Pinata.
+- Transfer logging, prescription management, and credential issuance flows that map directly to the Solidity contracts.
+- Ethers.js provider utilities (`src/services/*`) that encapsulate contract calls and simplify error handling.
 
-### `npm start`
+## Getting started
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+```bash
+cd front-end
+npm install
+cp .env.example .env      # update with your Pinata + RPC credentials
+npm start
+```
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+The development server runs on [http://localhost:3000](http://localhost:3000). Connect a wallet (MetaMask) that points at the same network as your deployed contracts and ensure the addresses in `src/constants/contracts.ts` match the latest deployment.
 
-### `npm test`
+## Project structure
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+| Path | Purpose |
+| --- | --- |
+| `src/components/` | Dashboard modules (role manager, batch forms, doctor/pharmacy views). |
+| `src/services/` | Thin wrappers around ethers.js, Pinata SDK, and other side effects. |
+| `src/abi/` | Contract ABIs generated from Hardhat builds. Regenerate after recompiling contracts. |
+| `src/constants/contracts.ts` | Central list of deployed contract addresses. Update after each deployment. |
 
-### `npm run build`
+## Scripts
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+| Command | Description |
+| --- | --- |
+| `npm start` | Run the development server with hot reloading. |
+| `npm test` | Execute unit tests generated via Create React App. |
+| `npm run build` | Produce an optimised production bundle in `build/`. |
+| `npm run lint` | (Configure ESLint) Validate coding style before committing. |
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+## Environment variables
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+Create React App exposes variables prefixed with `REACT_APP_`. Common configuration values:
 
-### `npm run eject`
+- `REACT_APP_PINATA_JWT`: JWT token for Pinata uploads.
+- `REACT_APP_GATEWAY_URL`: Pinata gateway for resolving CIDs.
+- `REACT_APP_DEFAULT_NETWORK`: Hex chain ID expected by the UI (e.g. `0x539` for Hardhat).
+- `REACT_APP_RPC_URL`: Optional RPC endpoint if you need to override the provider connection logic.
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+Restart the dev server after changing environment variables.
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+## Updating ABIs
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+After modifying any Solidity contract, run `npx hardhat compile` at the repository root and copy the generated JSON ABIs into `src/abi`. Keep the contract address map in sync to avoid signature mismatches.
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).


### PR DESCRIPTION
## Summary
- rewrite the top-level README, add detailed docs under `docs/`, and ship `.env.example` templates for quick setup
- update the consumer Flask demos to source Gemini credentials from environment variables instead of hard-coding keys
- align the `IDrugBatchRegistry` interface with the implementation and adjust dependent contracts to keep batch validation working

## Testing
- `npx hardhat compile` *(fails: Hardhat 3.x requires Node 22+; container provides Node 20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68cb035cb7848331a34bf0f55583d65d